### PR TITLE
Make compatible with Ghost 1.x

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -3,7 +3,7 @@
 {{#author}}
 <article class="page">
     <header>
-        <p><img src="{{image}}" alt="{{name}}" width="100" class="avatar"></p>
+        <p><img src="{{img_url profile_image}}" alt="{{name}}" width="100" class="avatar"></p>
         <h1>{{name}}</h1>
     </header>
     {{#if bio}}<p class="readable">{{bio}}</p>{{/if}}

--- a/partials/post-single.hbs
+++ b/partials/post-single.hbs
@@ -4,9 +4,9 @@
         {{> strip-navigation}}
     </header>
 
-    {{#if image}}
+    {{#if feature_image}}
     <div class="strip">
-        <img src="{{image}}" alt="{{title}}">
+        <img src="{{img_url feature_image}}" alt="{{title}}">
     </div>
     {{/if}}
 


### PR DESCRIPTION
Resolves #1 

Fixed errors thrown by Ghost when trying to add theme.
![image](https://user-images.githubusercontent.com/2633542/32807250-42c7d10a-c95d-11e7-8423-6fc3647e4066.png)

Changes only seemed to be required for `partials/post-single.hbs` and `author.hbs`, specifically needed to use updated [image helper](https://themes.ghost.org/docs/img_url).